### PR TITLE
Fixes autosave error when using MockStore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # DataKeep
 
+## [version 2.1.1](https://github.com/noahrepublic/DataKeep/releases/tag/v2.1.1): 12/05/2023
+
+### Fixes
+- Merged PR [#12](https://github.com/noahrepublic/DataKeep/pull/12)
+
 ## [version 2.1.0](https://github.com/noahrepublic/DataKeep/releases/tag/v2.1.0): 11/30/2023
 
 ### Added 

--- a/src/init.lua
+++ b/src/init.lua
@@ -223,7 +223,12 @@ local function createMockStore(storeInfo: StoreInfo, dataTemplate) -- complete m
 		_mock = true,
 
 		_keeps = {},
+
 		_cachedKeepPromises = {},
+
+		validate = function()
+			return true
+		end,
 	}, Store)
 end
 

--- a/wally.toml
+++ b/wally.toml
@@ -1,7 +1,7 @@
 [package]
 name = "noahrepublic/datakeep"
 description = "The final data saving solution you need"
-version = "2.1.0"
+version = "2.1.1"
 license = "MIT"
 authors = ["noahrepublic"]
 registry = "https://github.com/UpliftGames/wally-index"


### PR DESCRIPTION
This should fix the error caused by autosave when validate is missing. I tested this the same way I discovered the error, by idling for a few minutes after loading in, and it did not re-appear.