### PR TITLE
Added Implementation of "WriteLib"

### DIFF
--- a/src/init.lua
+++ b/src/init.lua
@@ -595,6 +595,14 @@ function Store:LoadKeep(key: string, unReleasedHandler: UnReleasedHandler): Prom
 				return func(...)
 			end
 		end
+		
+		if self.WriteLib then
+			for functionName, func in self.WriteLib do
+				keepClass[functionName] = function(...)
+					return func(...)
+				end
+			end
+		end
 
 		resolve(keepClass)
 	end)
@@ -670,6 +678,14 @@ function Store:ViewKeep(key: string, version: string?): Promise
 		for functionName, func in self.Wrapper do -- attach wrapper functions
 			keepObject[functionName] = function(...)
 				return func(...)
+			end
+		end
+		
+		if self.WriteLib then
+			for functionName, func in self.WriteLib do
+				keepClass[functionName] = function(...)
+					return func(...)
+				end
 			end
 		end
 


### PR DESCRIPTION
I could not find the code where WriteLib is implemented after looking through the code. I decided it was easy enough to add it myself. Here it is! Just a couple of more lines to add the WriteLib functions to the KeepObject. I did not do any checks on the functions and "Blindly" added them. Works though!